### PR TITLE
allow specifying the branch to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-mkdir -p $HOME/.local/share
-export PEARL_ROOT=$HOME/.local/share/pearl
-export PEARL_HOME=$HOME/.config/pearl
+[[ -n "$1" ]] && branch="--branch $1" || unset branch
 
-[ -d "$PEARL_ROOT" ] && { echo "Error: Pearl seems already installed in $PEARL_ROOT. Remove the directory in order to proceed with the installation."; exit 11; }
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+mkdir -p "$XDG_CONFIG_HOME"
+mkdir -p "$XDG_DATA_HOME"
+export PEARL_HOME="$XDG_CONFIG_HOME/pearl"
+export PEARL_ROOT="$XDG_DATA_HOME/pearl"
+
+if [[ -e "$PEARL_ROOT" ]]; then
+	printf '%s' "Error: It seems Pearl is already installed in $PEARL_ROOT."
+	printf '%s\n' ' Remove the directory to proceed with the installation.'
+	exit 11
+fi
 
 echo "* Downloading Pearl to $PEARL_ROOT"
-git clone --quiet 'https://github.com/pearl-core/pearl.git' $PEARL_ROOT
-cd $PEARL_ROOT
-git submodule update --quiet --init --recursive
+git clone --quiet $branch --depth 1  --recurse-submodules \
+	'https://github.com/pearl-core/pearl.git' "$PEARL_ROOT"
 
-$PEARL_ROOT/bin/pearl init
+"$PEARL_ROOT/bin/pearl" init


### PR DESCRIPTION
This pull request add the ability to specify the `git` branch to install.
This allows installing the `dev` branch when it has critical fixes, as is currently the case.

This pull request also
1. collapses the separate `git clone` and `git submodule` commands into a single `git clone` command,
2. does a shallow clone (`depth 1`) of the specified branch, and
3. uses [XDG base dirs](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) if defined.

Further, it maintains compability with `git` [1.8.0](https://git-scm.com/docs/git-clone/1.8.0) as defined in the current `pearl` [README.md](https://github.com/pearl-core/pearl/blob/479d87e8c2ca1d1bab52b76088e57246163901ad/README.md).